### PR TITLE
[rqt_play_motion_builder] fix plugin path and add install to CMake

### DIFF
--- a/rqt_play_motion_builder/CMakeLists.txt
+++ b/rqt_play_motion_builder/CMakeLists.txt
@@ -24,6 +24,11 @@ ament_auto_add_library(${PROJECT_NAME}_gui SHARED
 )
 target_link_libraries(${PROJECT_NAME}_gui Qt5::Widgets)
 
+install(
+  PROGRAMS scripts/rqt_play_motion_builder
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 # class_loader_hide_library_symbols(${PROJECT_NAME}_gui)
 
 pluginlib_export_plugin_description_file(rqt_gui "plugin.xml")
@@ -33,4 +38,3 @@ if(ament_cmake_auto_VERSION VERSION_LESS "2.6.0")
 else()
   ament_auto_package()
 endif()
-

--- a/rqt_play_motion_builder/scripts/rqt_play_motion_builder
+++ b/rqt_play_motion_builder/scripts/rqt_play_motion_builder
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/rqt_play_motion_builder/scripts/rqt_play_motion_builder
+++ b/rqt_play_motion_builder/scripts/rqt_play_motion_builder
@@ -5,4 +5,4 @@ import sys
 from rqt_gui.main import Main
 
 main = Main()
-sys.exit(main.main(sys.argv, standalone='pal/RQTPlayMotionBuilder'))
+sys.exit(main.main(sys.argv, standalone='rqt_play_motion_builder/RQTPlayMotionBuilder'))


### PR DESCRIPTION
rqt_play_motion_builder cannot be executed with `ros2 run rqt_play_motion_builder rqt_play_motion_builder` . This PR fixes it