### PR TITLE
remove -std= flags for building in jammy

### DIFF
--- a/play_motion_builder/CMakeLists.txt
+++ b/play_motion_builder/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(play_motion_builder)
 
-add_compile_options(-std=c++11)
-
 find_package(catkin REQUIRED
     COMPONENTS
     roscpp

--- a/play_motion_builder_msgs/CMakeLists.txt
+++ b/play_motion_builder_msgs/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(play_motion_builder_msgs)
 
-add_compile_options(-std=c++11)
-
 find_package(catkin REQUIRED COMPONENTS message_generation actionlib_msgs)
 
 ################################################

--- a/rqt_play_motion_builder/CMakeLists.txt
+++ b/rqt_play_motion_builder/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(rqt_play_motion_builder)
 
-add_compile_options(-std=c++11)
-
 find_package(catkin REQUIRED
   COMPONENTS
   roscpp
@@ -55,8 +53,6 @@ endif()
 
 include_directories(include)
 include_directories(SYSTEM ${CMAKE_CURRENT_BINARY_DIR} ${catkin_INCLUDE_DIRS})
-
-add_compile_options(-std=c++11)
 
 add_library(${PROJECT_NAME}_gui
   src/rqt_play_motion_builder.cpp


### PR DESCRIPTION
I want to release this repository for ros-o + Ubuntu Jammy. This PR fixes

```
/usr/bin/c++ -DROSCONSOLE_BACKEND_LOG4CXX -DROS_BUILD_SHARED_LIBS=1 -DROS_PACKAGE_NAME=\"play_motion_builder\" -Dmotion_model_lib_EXPORTS -I/<<BUILDDIR>>ros-one-play-motion-builder-1.2.0/include -isystem /opt/ros/one/include -isystem /opt/ros/one/share/xmlrpcpp/cmake/../../../include/xmlrpcpp -g -O2 -ffile-prefix-map=/<<BUILDDIR>>ros-one-play-motion-builder-1.2.0=. -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -std=c++11 -MD -MT CMakeFiles/motion_model_lib.dir/src/motion_model.cpp.o -MF CMakeFiles/motion_model_lib.dir/src/motion_model.cpp.o.d -o CMakeFiles/motion_model_lib.dir/src/motion_model.cpp.o -c /<<BUILDDIR>>ros-one-play-motion-builder-1.2.0/src/motion_model.cpp
  In file included from /usr/include/log4cxx/log4cxx.h:45,
                   from /usr/include/log4cxx/logstring.h:28,
                   from /usr/include/log4cxx/level.h:22,
                   from /opt/ros/one/include/ros/console.h:46,
                   from /opt/ros/one/include/ros/ros.h:40,
                   from /<<BUILDDIR>>ros-one-play-motion-builder-1.2.0/include/play_motion_builder/motion_model.h:4,
                   from /<<BUILDDIR>>ros-one-play-motion-builder-1.2.0/src/motion_model.cpp:1:
  /usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
     10 |     typedef std::shared_mutex shared_mutex;
        |                  ^~~~~~~~~~~~
  /usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
     10 |     typedef std::shared_mutex shared_mutex;
        |             ^~~
  /usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
     12 |     using shared_lock = std::shared_lock<T>;
        |                              ^~~~~~~~~~~
  /usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards
     12 |     using shared_lock = std::shared_lock<T>;
        |                         ^~~
  make[4]: *** [CMakeFiles/motion_model_lib.dir/build.make:79: CMakeFiles/motion_model_lib.dir/src/motion_model.cpp.o] Error 1
  make[4]: Leaving directory '/<<BUILDDIR>>ros-one-play-motion-builder-1.2.0/.obj-x86_64-linux-gnu'
  make[3]: *** [CMakeFiles/Makefile2:1357: CMakeFiles/motion_model_lib.dir/all] Error 2
  make[3]: Leaving directory '/<<BUILDDIR>>ros-one-play-motion-builder-1.2.0/.obj-x86_64-linux-gnu'
  make[2]: *** [Makefile:139: all] Error 2
  make[2]: Leaving directory '/<<BUILDDIR>>ros-one-play-motion-builder-1.2.0/.obj-x86_64-linux-gnu'
  dh_auto_build: error: cd .obj-x86_64-linux-gnu && make -j4 "INSTALL=install --strip-program=true" VERBOSE=1 returned exit code 2
  make[1]: *** [debian/rules:45: override_dh_auto_build] Error 25
  make[1]: Leaving directory '/<<BUILDDIR>>ros-one-play-motion-builder-1.2.0'
  make: *** [debian/rules:27: build] Error 2

```