### PR TITLE
add skip_planning param for non-moveit robot

### DIFF
--- a/play_motion_builder/src/play_motion_builder.cpp
+++ b/play_motion_builder/src/play_motion_builder.cpp
@@ -369,6 +369,9 @@ void ROSMotionBuilderNode::executeRunMotionCb(const play_motion_builder_msgs::Ru
     // Execute the motion
     play_motion_msgs::PlayMotionGoal motion_goal;
     motion_goal.motion_name = motion_->getParamName();
+    // Allow skipping the approach planner (required when play_motion runs with
+    // disable_motion_planning, e.g. robots without a MoveIt move_group).
+    motion_goal.skip_planning = private_nh_.param("skip_planning", false);
     play_motion_client_.sendGoal(motion_goal);
 
     // Track goal


### PR DESCRIPTION
The robot without MoveIt requires a skip-planning flag in the actionlib goal. When using rqt_play_motion_builder, it is inconvenient, so this PR supports the rosparam flag. 